### PR TITLE
Added code to display the sizes of homebrew.

### DIFF
--- a/src/Views/HomebrewView/homebrewView.cpp
+++ b/src/Views/HomebrewView/homebrewView.cpp
@@ -8,6 +8,10 @@
 #include <psp2/io/fcntl.h>
 #include <psp2/io/stat.h>
 #include <vitaPackage.h>
+#include <sstream>
+#include <cmath> 
+
+
 
 extern unsigned char _binary_assets_spr_img_preview_infobg_png_start;
 extern unsigned char _binary_assets_spr_img_preview_btn_download_png_start;
@@ -207,6 +211,16 @@ void HomebrewView::startYoutube() const
         0x20000, (std::string("webmodal: https://www.youtube.com/embed/") + hb_.trailer + "?autoplay=1").c_str());
 }
 
+std::string HomebrewView::sizeRoundAndString(int sizeinbytes){
+    double i = 0.000001*sizeinbytes;
+i = round( i * 100.0 ) / 100.0;
+std::string sizevalueinmb;
+std::stringstream ss;
+ss << i;
+sizevalueinmb = ss.str() + "MB";
+return sizevalueinmb;
+}
+
 int HomebrewView::Display()
 {
     bg.Display();
@@ -217,7 +231,7 @@ int HomebrewView::Display()
     font_40.Draw(Point(HB_X + 225, HB_Y + 88), hb_.name, COLOR_WHITE);
     font_25.Draw(Point(HB_X + 225, HB_Y + 115), hb_.author, COLOR_AQUA);
     font_25.Draw(Point(HB_X + 225, HB_Y + 144), hb_.version, COLOR_WHITE);
-    // font_20.Draw(Point(HB_X + 100, HB_Y + 189), std::string("0 Kb"), COLOR_WHITE);
+    font_20.Draw(Point(HB_X + 100, HB_Y + 200), sizeRoundAndString(hb_.size+hb_.datasize), COLOR_WHITE);
     // font_20.Draw(Point(HB_X + 850, HB_Y + 503), hb_.date.str, COLOR_WHITE);
 
     font_25.Draw(Point(HB_X + 40, HB_Y + 362), description);

--- a/src/Views/HomebrewView/homebrewView.h
+++ b/src/Views/HomebrewView/homebrewView.h
@@ -48,4 +48,5 @@ private:
     void checkInstalled();
     void homebrewInstall();
     void startYoutube() const;
+    std::string sizeRoundAndString(int);
 };

--- a/src/homebrew.cpp
+++ b/src/homebrew.cpp
@@ -55,7 +55,8 @@ namespace YAML
         hb.url = node["url"].as<std::string>();
         if (node["data"])
             hb.data = node["data"].as<std::string>();
-
+        hb.size = node["size"].as<int>();
+        hb.datasize = node["data_size"].as<int>();
         return true;
     }
 }; // namespace YAML

--- a/src/homebrew.h
+++ b/src/homebrew.h
@@ -22,6 +22,8 @@ public:
 	std::vector<std::string> screenshots;
 	std::string url;
 	std::string data;
+	int size;
+	int datasize;
 
 	bool IsInstalled();
 };


### PR DESCRIPTION
When looking through how VitaDB does it's database I saw a size thing so I added it into the homebrew information screen. It's displayed in MB using the same position as the code snippet that was commented out.