### PR TITLE
Dynamic list item loading

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ string(REGEX REPLACE "0+0\\." "0." VITA_VERSION_HUMAN ${VITA_VERSION})
 
 set(VERSION_YAML_URL "https://vhbb.download/version.php")
 set(UPDATE_URL "https://github.com/devnoname120/vhbb/releases/download/${VITA_VERSION_HUMAN}/VitaHBBrowser.vpk")
-# Old test URL's
+# Old test URLs
 #set(VERSION_YAML_URL "https://github.com/robsdedude/vhbb/raw/updateTestBranch/release/version.yml")
 #set(UPDATE_URL "https://github.com/robsdedude/vhbb/raw/updateTestBranch/release/VitaHBBrowser.vpk")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,7 +217,7 @@ if (EXISTS "${psvitaipFilePath}")
     file(STRINGS "${psvitaipFilePath}" PSVITAIP)
 
     add_custom_target(send
-            COMMAND curl -T ${SHORT_NAME}.self ftp://${PSVITAIP}:1337/ux0:/app/${VITA_TITLEID}/eboot.bin
+            COMMAND curl --ftp-method nocwd  -T ${SHORT_NAME}.self ftp://${PSVITAIP}:1337/ux0:/app/${VITA_TITLEID}/eboot.bin
             DEPENDS ${SHORT_NAME}.self
             )
 
@@ -227,7 +227,7 @@ if (EXISTS "${psvitaipFilePath}")
             )
 
     add_custom_target(vpksend
-            COMMAND curl -T ${SHORT_NAME}.vpk ftp://${PSVITAIP}:1337/ux0:/
+            COMMAND curl --ftp-method nocwd  -T ${SHORT_NAME}.vpk ftp://${PSVITAIP}:1337/ux0:/
             DEPENDS ${SHORT_NAME}.vpk
             )
 else ()

--- a/src/Views/ListView/listView.cpp
+++ b/src/Views/ListView/listView.cpp
@@ -89,7 +89,7 @@ ListView::ListView(std::vector<Homebrew> homebrews)
     log_printf(DBG_DEBUG, "posY: %d", posY);
     log_printf(DBG_DEBUG, "homebrews size: %d", homebrews.size());
     this->homebrews = homebrews;
-    listItems = std::vector<ListItem*>(homebrews.size(), nullptr);
+    listItems = std::vector<std::unique_ptr<ListItem>>(homebrews.size());
     LoadListItems();
 }
 
@@ -100,7 +100,7 @@ long ListView::_LoadPreviousListItems(long firstDisplayed, long firstToLoad, lon
     {
         if (!listItems[i])
         {
-            listItems[i] = new ListItem(homebrews[i]);
+            listItems[i] = std::make_unique<ListItem>(homebrews[i]);
             if (++loaded > maxLoad)
             {
                 break;
@@ -117,7 +117,7 @@ long ListView::_LoadShownListItems(long firstDisplayed, long lastDisplayed, long
     {
         if (!listItems[i])
         {
-            listItems[i] = new ListItem(homebrews[i]);
+            listItems[i] = std::make_unique<ListItem>(homebrews[i]);
             if (++loaded > maxLoad)
             {
                 break;
@@ -134,7 +134,7 @@ long ListView::_LoadNextListItems(long lastDisplayed, long lastToLoad, long maxL
     {
         if (!listItems[i])
         {
-            listItems[i] = new ListItem(homebrews[i]);
+            listItems[i] = std::make_unique<ListItem>(homebrews[i]);
             if (++loaded > maxLoad)
             {
                 break;
@@ -153,19 +153,11 @@ void ListView::LoadListItems()
     long loaded = 0;
     for (long i = 0; i < firstToLoad; i++)
     {
-        if (listItems[i])
-        {
-            delete listItems[i];
-            listItems[i] = nullptr;
-        }
+        listItems[i] = nullptr;
     }
     for (long i = lastToLoad; i < (long)listItems.size(); i++)
     {
-        if (listItems[i])
-        {
-            delete listItems[i];
-            listItems[i] = nullptr;
-        }
+        listItems[i] = nullptr;
     }
 
     loaded += _LoadShownListItems(first, last, MAX_LOAD_LIST_ITEMS_PER_CYCLE);

--- a/src/Views/ListView/listView.cpp
+++ b/src/Views/ListView/listView.cpp
@@ -88,9 +88,107 @@ ListView::ListView(std::vector<Homebrew> homebrews)
 {
     log_printf(DBG_DEBUG, "posY: %d", posY);
     log_printf(DBG_DEBUG, "homebrews size: %d", homebrews.size());
-    for (Homebrew hb : homebrews)
+    this->homebrews = homebrews;
+    listItems = std::vector<ListItem*>(homebrews.size(), nullptr);
+    LoadListItems();
+}
+
+long ListView::_LoadPreviousListItems(long firstDisplayed, long firstToLoad, long maxLoad)
+{
+    long loaded = 0;
+    for (long i = firstDisplayed; i >= firstToLoad; i--)
     {
-        listItems.emplace_back(hb);
+        if (!listItems[i])
+        {
+            listItems[i] = new ListItem(homebrews[i]);
+            if (++loaded > maxLoad)
+            {
+                break;
+            }
+        }
+    }
+    return loaded;
+}
+
+long ListView::_LoadShownListItems(long firstDisplayed, long lastDisplayed, long maxLoad)
+{
+    long loaded = 0;
+    for (long i = firstDisplayed; i <= lastDisplayed; i++)
+    {
+        if (!listItems[i])
+        {
+            listItems[i] = new ListItem(homebrews[i]);
+            if (++loaded > maxLoad)
+            {
+                break;
+            }
+        }
+    }
+    return loaded;
+}
+
+long ListView::_LoadNextListItems(long lastDisplayed, long lastToLoad, long maxLoad)
+{
+    long loaded = 0;
+    for (long i = lastDisplayed; i <= lastToLoad; i++)
+    {
+        if (!listItems[i])
+        {
+            listItems[i] = new ListItem(homebrews[i]);
+            if (++loaded > maxLoad)
+            {
+                break;
+            }
+        }
+    }
+    return loaded;
+}
+
+void ListView::LoadListItems()
+{
+    auto first = (long)firstDisplayedItem();
+    auto last = (long)lastDisplayedItem();
+    long firstToLoad = std::max<long>(first - PRE_RENDER_EXTRA_LIST_ITEM, 0);
+    long lastToLoad = std::min<long>(last + PRE_RENDER_EXTRA_LIST_ITEM, listItems.size());
+    long loaded = 0;
+    for (long i = 0; i < firstToLoad; i++)
+    {
+        if (listItems[i])
+        {
+            delete listItems[i];
+            listItems[i] = nullptr;
+        }
+    }
+    for (long i = lastToLoad; i < (long)listItems.size(); i++)
+    {
+        if (listItems[i])
+        {
+            delete listItems[i];
+            listItems[i] = nullptr;
+        }
+    }
+
+    loaded += _LoadShownListItems(first, last, MAX_LOAD_LIST_ITEMS_PER_CYCLE);
+    if (loaded >= MAX_LOAD_LIST_ITEMS_PER_CYCLE)
+        return;
+
+    if (scrollSpeed >= 0)
+    {
+        // preferably pre-load further down the list
+        loaded += _LoadNextListItems(first, last, MAX_LOAD_LIST_ITEMS_PER_CYCLE);
+        if (loaded >= MAX_LOAD_LIST_ITEMS_PER_CYCLE)
+            return;
+        loaded += _LoadPreviousListItems(first, last, MAX_LOAD_LIST_ITEMS_PER_CYCLE);
+        if (loaded >= MAX_LOAD_LIST_ITEMS_PER_CYCLE)
+            return;
+    } else {
+        // preferably pre-load further up the list
+        loaded += _LoadPreviousListItems(first, last, MAX_LOAD_LIST_ITEMS_PER_CYCLE);
+        if (loaded >= MAX_LOAD_LIST_ITEMS_PER_CYCLE)
+            return;
+        loaded += _LoadNextListItems(first, last, MAX_LOAD_LIST_ITEMS_PER_CYCLE);
+        if (loaded >= MAX_LOAD_LIST_ITEMS_PER_CYCLE)
+            return;
     }
 }
 
@@ -127,7 +225,7 @@ int ListView::HandleInput(int focus, const Input& input)
                 log_printf(DBG_DEBUG, "Clicked, adding view...");
                 try
                 {
-                    Activity::get_instance()->AddView(std::make_shared<HomebrewView>(listItems.at(selectedItem).homebrew));
+                    Activity::get_instance()->AddView(std::make_shared<HomebrewView>(homebrews.at(selectedItem)));
                 }
                 catch (const std::exception& ex)
                 {
@@ -205,7 +303,7 @@ int ListView::HandleInput(int focus, const Input& input)
                 log_printf(DBG_DEBUG, "Pressed, adding view...");
                 try
                 {
-                    Activity::get_instance()->AddView(std::make_shared<HomebrewView>(listItems.at(selectedItem).homebrew));
+                    Activity::get_instance()->AddView(std::make_shared<HomebrewView>(homebrews.at(selectedItem)));
                 }
                 catch (const std::exception& ex)
                 {
@@ -227,6 +325,8 @@ int ListView::HandleInput(int focus, const Input& input)
         }
     }
 
+    LoadListItems();
+
     return 0;
 }
 
@@ -246,7 +346,10 @@ int ListView::Display()
     }
     for (int i = firstDisplayedItem(); i <= lastDisplayedItem(); i++)
     {
-        listItems[i].Display(itemPosY(i), i == selectedItem, itemHighlightAlpha);
+        if(listItems[i])
+        {
+            listItems[i]->Display(itemPosY(i), i == selectedItem, itemHighlightAlpha);
+        }
     }
     if (itemHighlightDirection)
     {

--- a/src/Views/ListView/listView.h
+++ b/src/Views/ListView/listView.h
@@ -10,6 +10,8 @@
 #define LIST_MAX_Y 543 // This ordinate is included too
 #define LIST_RANGE_Y (LIST_MAX_Y - LIST_MIN_Y)
 #define LIST_HEIGHT (LIST_RANGE_Y + 1)
+#define PRE_RENDER_EXTRA_LIST_ITEM 30
+#define MAX_LOAD_LIST_ITEMS_PER_CYCLE 1
 
 // Max speed px/ms above which selected item is no more selected
 #define LIST_SELECTION_MAX_SPEED 0.000070
@@ -27,7 +29,9 @@ public:
 	virtual bool IsReadyToShow() { return true; };
 
 protected:
-	std::vector<ListItem> listItems;
+	std::vector<Homebrew> homebrews;
+	std::vector<ListItem*> listItems;
+	void LoadListItems();
 
 private:
 	Font font_43;
@@ -49,4 +53,7 @@ private:
 	unsigned int lastFullyDisplayedItem();
 	int coordinateToItem(double coordY);
 	int updateScrollSpeed(double &scrollSpeed, unsigned long timeDif);
+	long _LoadPreviousListItems(long firstDisplayed, long firstToLoad, long maxLoad);
+	long _LoadShownListItems(long firstDisplayed, long lastDisplayed, long maxLoad);
+	long _LoadNextListItems(long lastDisplayed, long lastToLoad, long loadMax);
 };

--- a/src/Views/ListView/listView.h
+++ b/src/Views/ListView/listView.h
@@ -30,7 +30,7 @@ public:
 
 protected:
 	std::vector<Homebrew> homebrews;
-	std::vector<ListItem*> listItems;
+	std::vector<std::unique_ptr<ListItem>> listItems;
 	void LoadListItems();
 
 private:

--- a/src/Views/ListView/searchView.cpp
+++ b/src/Views/ListView/searchView.cpp
@@ -35,11 +35,8 @@ int SearchView::Display()
             std::vector<Homebrew> hbs;
             hbs = db->Search(SearchQuery(_ime_search_view_result->userText));
             homebrews = hbs;
-            for (ListItem* item: listItems) {
-                delete item;
-            }
-            listItems.clear();
-            listItems = std::vector<ListItem*>(homebrews.size(), nullptr);
+
+            std::fill(listItems.begin(), listItems.end(), nullptr);
             LoadListItems();
             lastQuery = _ime_search_view_result->userText;
         }

--- a/src/Views/ListView/searchView.cpp
+++ b/src/Views/ListView/searchView.cpp
@@ -34,11 +34,13 @@ int SearchView::Display()
             auto db = Database::get_instance();
             std::vector<Homebrew> hbs;
             hbs = db->Search(SearchQuery(_ime_search_view_result->userText));
-            listItems.clear();
-            for (Homebrew hb : hbs)
-            {
-                listItems.emplace_back(hb);
+            homebrews = hbs;
+            for (ListItem* item: listItems) {
+                delete item;
             }
+            listItems.clear();
+            listItems = std::vector<ListItem*>(homebrews.size(), nullptr);
+            LoadListItems();
             lastQuery = _ime_search_view_result->userText;
         }
         else


### PR DESCRIPTION
This fixes #75 but it makes the search more fragile.  
Feel free to play around with `PRE_RENDER_EXTRA_LIST_ITEM` and `MAX_LOAD_LIST_ITEMS_PER_CYCLE` in `src/Views/ListView/listView.h`. They will modify the smoothness of scrolling and the memory footprint.

Now about the search. Things I found out:
 - It currently crashes when you filter with broad terms. Do a search with "a", then "e", then "i", etc. Eventually it will crash exactly when you try to open the search window. I wasn't able to figure out why this happens. But it's certainly better to have a sometimes crashing search than an always crashing app.
 - The search also crashes on the master version, it's just harder to get it to crash. You'll need more searches until it breaks.
 - Commenting out `src/Views/ListView/searchView.cpp` lines 34-43 (which as expected makes the search do nothing but always show all homebrews) seems to fix the crashing.

Thus, I assume it is a memory leak or so, but I couldn't find a way to fix it. Sorry, I'm still not a c/c++ developer :man_shrugging:. Maybe you could have a look and find what's wrong.

PS: I marked it as WIP because of the search issue. Feel free to merge it anyway, if you want a hotfix. I won't continue the bug hunt until I have new input on this.